### PR TITLE
Update MetaMaskWallet.cs for 5.15.1

### DIFF
--- a/Assets/Thirdweb/Runtime/Unity/Wallets/Core/MetaMaskWallet.cs
+++ b/Assets/Thirdweb/Runtime/Unity/Wallets/Core/MetaMaskWallet.cs
@@ -191,11 +191,42 @@ namespace Thirdweb.Unity
             throw new NotImplementedException();
         }
 
-        public Task Disconnect()
+               public async Task Disconnect()
+{
+    // Attempt to revoke "eth_accounts" permissions so the user has to re-approve next time
+    ThirdwebDebug.Log("Attempting to revoke MetaMask site permissions...");
+
+    // Construct the request using "wallet_revokePermissions".
+    var rpcRequest = new RpcRequest
+    {
+        Method = "wallet_revokePermissions",
+        // Expecting an array of permission types, here we just revoke 'eth_accounts'
+        Params = new object[]
         {
-            ThirdwebDebug.Log("Disconnecting has no effect on this wallet.");
-            return Task.CompletedTask;
+            new Dictionary<string, object>
+            {
+                { "eth_accounts", new object() }
+            }
         }
+    };
+
+    try
+    {
+        // Make the call to MetaMask via WebGL bridge.
+        var result = await WebGLMetaMask.Instance.RequestAsync<string>(rpcRequest);
+
+        ThirdwebDebug.Log($"Revoke permissions result: {result}");
+    }
+    catch (Exception ex)
+    {
+        // If the user’s wallet does not support 'wallet_revokePermissions'
+        // or if the user cancels, it gets an error
+        ThirdwebDebug.Log($"Failed to revoke permissions: {ex.Message}");
+    }
+
+    
+    ThirdwebDebug.Log("Disconnect complete (attempted revoke).");
+}
 
         public Task<List<LinkedAccount>> LinkAccount(
             IThirdwebWallet walletToLink,


### PR DESCRIPTION
This update modifies the Disconnect method in MetaMaskWallet.cs to address a key limitation in its previous implementation, particularly for WebGL environments.

Previously, the Disconnect method performed a "soft disconnect." As a result, users were unable to switch wallets within the same MetaMask extension without first revoking permissions in the wallet. Upon reconnection, the system would automatically connect to the previously authorized wallet.

The updated implementation ensures a more robust disconnection process, allowing users to seamlessly switch wallets within the MetaMask extension without the need for manual revocation. This enhancement improves user experience and aligns with expected wallet management functionality.

- Why this change?

The soft disconnect behavior created unnecessary friction for users, especially those needing to manage multiple wallets. By implementing a proper disconnect process, this update simplifies wallet switching and ensures greater flexibility for WebGL applications integrating MetaMask.